### PR TITLE
Add support to collect Helm V2 and V3 releases simultaneously

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Also, if you requested the object from the API server on a specific apiVersion, 
     The number of threads to handle helm check releases
 
 ``--max``
-    Maximum number of releases to fetch
+    Maximum number of releases to fetch (Default: 256)
 
 ``--interval``
     The interval between helm check releases jobs. Accepted suffix (s, m, h, d, w). Default is (1d)"
@@ -59,7 +59,10 @@ Also, if you requested the object from the API server on a specific apiVersion, 
     The database file location
 
 ``--helm-binary``
-    The helm binary to be used for running helm commands. Default is helm v2. Options: helm or helm3
+    The helm binary to be used. Default is helm v2. Use "helm" for helm V2 and "helm3" for helm V3
+
+``--helm-version``
+    The helm version to be used to collect the deployed releases. This argument can be used to collect the releases of helm v2 and helm v3 simultaneously. Default is v2. Use "v2" for helm V2, "v3" for helm V3, and "v23" for both helm v2 and v3 releases. When providing this argument, helm binary is not considered since the default binary of the provided helm version will be used
 
 ### Using the CLI
 
@@ -115,7 +118,7 @@ docker run --rm -v ~/.kube/config:/home/app/.kube/config aelbakry/kdave:latest -
     The Kubernetes version. If not provided, it defaults to the current cluster version
 
 ``--helm-binary``
-    The helm binary to be used for running helm commands. Default is helm v2. Use "helm" for helm V2 and "helm3" for helm V3
+    The helm binary to be used. Default is helm v2. Use "helm" for helm V2 and "helm3" for helm V3
 
 ``--output-dir``
     The output directory used to template the chart

--- a/exporter/app.py
+++ b/exporter/app.py
@@ -1141,15 +1141,7 @@ if __name__ == "__main__":
     helm = multiprocessing.Process(
         name="helm-handler",
         target=export_deprecated_versions_metrics,
-        args=(
-            args.threads,
-            q,
-            exit_event,
-            error_event,
-            helm_binary,
-            k8s_version,
-            max,
-        ),
+        args=(args.threads, q, exit_event, error_event, helm_binary, k8s_version, max),
         kwargs={"data_file": args.data_file, "helm_version": args.helm_version},
     )
 

--- a/exporter/app.py
+++ b/exporter/app.py
@@ -25,9 +25,12 @@ from prometheus_client.core import CollectorRegistry
 from exporter.constants import (
     DATA_FILE,
     DEFAULT_VERSIONS_FILE,
+    HELM_2_VERSION,
+    HELM_3_VERSION,
     HELM_TEMPLATE_TMP_DIRECTORY,
     HELM_V2_BINARY,
     HELM_V3_BINARY,
+    MAXIMUM,
 )
 from exporter.exceptions import (
     DeprecatedAPIVersionError,
@@ -50,8 +53,7 @@ from exporter.helper import (
     load_multiple_yaml_documents,
     load_yaml_file,
     parse_duration,
-    put_all_releases_in_queue,
-    put_all_releases_v3_in_queue,
+    put_all_helm_releases_in_queue,
 )
 
 app = Flask(__name__)
@@ -467,7 +469,7 @@ def handle_deprecation_in_files_output(k8s_version: str, files: list):
 
 
 def check_deprecation_for_namespace_releases(
-    helm_binary: str, namespace: str, k8s_version: str = None
+    helm_binary: str, namespace: str, k8s_version: str = None, helm_version: str = None
 ):
     """
     Check the deprecated apiVersions for all the releases in a namespace.
@@ -577,13 +579,19 @@ def raise_api_versions_exception(deprecations: List[Dict]) -> None:
         raise DeprecatedAPIVersionError
 
 
-def get_kinds_from_helm_release(
-    helm_binary: str, release_name: str, namespace: str = None
+def get_kinds_from_helm_release(  # noqa: C901
+    helm_binary: str, release_name: str, namespace: str = None, helm_version: str = None
 ):
     """
     Get all kinds from a helm release a long with the apiVersions to check the deprecation
     """
     result: List = []
+
+    if helm_version == HELM_2_VERSION:
+        helm_binary = HELM_V2_BINARY
+    elif helm_version == HELM_3_VERSION:
+        helm_binary = HELM_V3_BINARY
+
     try:
         release_info = helm_get(helm_binary, release_name, namespace)
     except HelmCommandError:
@@ -612,7 +620,11 @@ def get_kinds_from_helm_release(
 
 
 def get_deployed_deprecated_kinds(
-    helm_binary: str, release_name: str, namespace: str = None, k8s_version: str = None
+    helm_binary: str,
+    release_name: str,
+    namespace: str = None,
+    k8s_version: str = None,
+    helm_version: str = None,
 ):
     """
     Get the deprecated apiVersions for the deployed kinds which are fetched from a helm release.
@@ -620,7 +632,9 @@ def get_deployed_deprecated_kinds(
     result: List = []
     version = k8s_version if k8s_version else _k8s_version()
 
-    kinds = get_kinds_from_helm_release(helm_binary, release_name, namespace)
+    kinds = get_kinds_from_helm_release(
+        helm_binary, release_name, namespace, helm_version
+    )
 
     if not kinds:
         return result
@@ -657,6 +671,7 @@ def handle_release_deprecation(  # noqa: C901
                 release_info["name"],
                 release_info["namespace"],
                 k8s_version=k8s_version,
+                helm_version=release_info["helm_version"],
             )
             deprecated = "false"
             removed = "false"
@@ -670,6 +685,8 @@ def handle_release_deprecation(  # noqa: C901
             releases.append(
                 {
                     "release_name": release_info["name"],
+                    "namespace": release_info["namespace"],
+                    "helm_version": release_info["helm_version"],
                     "has_deprecated_api_versions": deprecated,
                     "has_removed_api_versions": removed,
                 }
@@ -677,6 +694,7 @@ def handle_release_deprecation(  # noqa: C901
 
             for dep in deprecated_kinds:
                 dep["release_last_update"] = release_info["release_last_update"]
+                dep["helm_version"] = release_info["helm_version"]
 
                 result.append(dep)
         except queue.Empty:
@@ -707,10 +725,11 @@ def get_deprecations_for_all_releases(
     error_event: threading.Event,
     helm_binary: str,
     k8s_version: str,
+    max: int,
     app_data=app_data,
     lock=lock,
     data_file: str = DATA_FILE,
-    max: int = None,
+    helm_version: str = None,
 ):
 
     set_trigger_flag(lock, app_data=app_data)
@@ -729,11 +748,7 @@ def get_deprecations_for_all_releases(
         start = time.time()
 
         put_releases_in_queue = threading.Thread(
-            target=(
-                put_all_releases_v3_in_queue
-                if helm_binary == HELM_V3_BINARY
-                else put_all_releases_in_queue
-            ),
+            target=put_all_helm_releases_in_queue,
             name="put_releases_in_queue",
             daemon=True,
             kwargs={
@@ -742,6 +757,7 @@ def get_deprecations_for_all_releases(
                 "exit_event": exit_event,
                 "error_event": error_event,
                 "max": max,
+                "helm_version": helm_version,
             },
         )
 
@@ -863,11 +879,12 @@ def export_deprecated_versions_metrics(
     error_event: threading.Event,
     helm_binary: str,
     k8s_version: str,
+    max: int,
     app_data: dict = app_data,
     lock=lock,  # Manager.Lock
     data_file: str = DATA_FILE,
     run_once: bool = False,
-    max: int = None,
+    helm_version: str = None,
 ):
 
     while True:
@@ -881,10 +898,11 @@ def export_deprecated_versions_metrics(
                 error_event,
                 helm_binary,
                 k8s_version,
-                max=max,
+                max,
                 app_data=app_data,
                 lock=lock,
                 data_file=data_file,
+                helm_version=helm_version,
             )
 
         if run_once:
@@ -953,6 +971,7 @@ def get_metrics():
             "name",
             "release_name",
             "namespace",
+            "helm_version",
             "replacement_api",
             "deprecated_in_version",
             "removed_in_version",
@@ -1006,6 +1025,7 @@ def get_metrics():
             metric["name"],
             metric["release_name"],
             metric["namespace"],
+            metric["helm_version"],
             metric["replacement_api"],
             metric["deprecated_in_version"],
             metric["removed_in_version"],
@@ -1066,7 +1086,11 @@ def get_arguments():
         default="2h",
     )
     parser.add_argument(
-        "-m", "--max", help="Maximum number of releases to fetch", type=int
+        "-m",
+        "--max",
+        help="Maximum number of releases to fetch",
+        type=int,
+        default=MAXIMUM,
     )
     parser.add_argument(
         "-d",
@@ -1082,6 +1106,13 @@ def get_arguments():
         type=str,
         default=HELM_V2_BINARY,
     )
+    parser.add_argument(
+        "-e",
+        "--helm-version",
+        help='The helm version to be used to collect the deployed releases. This argument can be used to collect the releases of helm v2 and helm v3 simultaneously. Default is v2. Use "v2" for helm V2, "v3" for helm V3, and "v23" for both helm v2 and v3 releases. When providing this argument, helm binary is not considered since the default binary of the provided helm version will be used',
+        type=str,
+        default=None,
+    )
     args = parser.parse_args()
 
     return args
@@ -1091,7 +1122,9 @@ if __name__ == "__main__":
     args = get_arguments()
     interval = args.interval
     delay = args.delay
+    max = args.max
     helm_binary = args.helm_binary
+    helm_version = args.helm_version
     q: queue.Queue = queue.Queue()
     exit_event = threading.Event()
     error_event = threading.Event()
@@ -1108,8 +1141,16 @@ if __name__ == "__main__":
     helm = multiprocessing.Process(
         name="helm-handler",
         target=export_deprecated_versions_metrics,
-        args=(args.threads, q, exit_event, error_event, helm_binary, k8s_version),
-        kwargs={"data_file": args.data_file, "max": args.max},
+        args=(
+            args.threads,
+            q,
+            exit_event,
+            error_event,
+            helm_binary,
+            k8s_version,
+            max,
+        ),
+        kwargs={"data_file": args.data_file, "helm_version": args.helm_version},
     )
 
     flask_app.start()

--- a/exporter/constants.py
+++ b/exporter/constants.py
@@ -4,8 +4,12 @@ DEFAULT_VERSIONS_FILE = "config/versions.yaml"
 HELM_TEMPLATE_TMP_DIRECTORY = "/tmp/helm_template_tmp_dir"
 HELM_V2_BINARY = "helm"
 HELM_V3_BINARY = "helm3"
+HELM_2_VERSION = "v2"
+HELM_3_VERSION = "v3"
+HELM_2_AND_3_VERSION = "v23"  # Used to collect both Helm V2 and V3 releases
 DATA_FILE = "data/data.json"
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+MAXIMUM = 256  # Maximum Number of releases to fetch at once
 DEPRECATED_API_EXIT_CODE = 0
 REMOVED_NEXT_RELEASE_API_EXIT_CODE = 0
 REMOVED_API_EXIT_CODE = 10  # Non-zero exit code.

--- a/exporter/helper.py
+++ b/exporter/helper.py
@@ -196,7 +196,7 @@ def helm_build_dependencies(helm_binary: str, chart_path: str):
     _run_helm_command(helm_command)
 
 
-def helm_template( # noqa: C901
+def helm_template(  # noqa: C901
     chart_path: str,
     output_dir: str,
     helm_binary: str,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -523,13 +523,16 @@ def test_get_deployed_deprecated_kinds__success(mocker):
 
 
 def test_get_deprecations_for_all_releases__update_existing_data__success(mocker):
+    K8s_VERSION = "v1.21.0"
+    MAXIMUM = 256
     app.get_deprecations_for_all_releases(
         1,
         app.queue.Queue,
         app.threading.Event(),
         app.threading.Event(),
         HELM_V2_BINARY,
-        "v1.21.0",
+        K8s_VERSION,
+        MAXIMUM,
         app_data=app.app_data,
         lock=app.lock,
         data_file="tests/fixtures/data.json",
@@ -550,6 +553,8 @@ def test_load_from_data_file__success():
 
 
 def test_export_deprecated_versions_metrics__success(mocker):
+    K8s_VERSION = "v1.21.0"
+    MAXIMUM = 256
     mocked_queue = mocker.patch("exporter.app.queue.Queue")
     mocked_exit_event = mocker.patch("exporter.app.threading.Event")
     mocked_error_event = mocker.patch("exporter.app.threading.Event")
@@ -566,12 +571,12 @@ def test_export_deprecated_versions_metrics__success(mocker):
         mocked_exit_event,
         mocked_error_event,
         HELM_V2_BINARY,
-        "v1.21.0",
+        K8s_VERSION,
+        MAXIMUM,
         app_data=app.app_data,
         lock=mocked_lock,
         data_file="tests/fixtures/data.json",
         run_once=True,
-        max=100,
     )
     get_deprecations_for_all_releases_mocker.assert_called_with(
         1,
@@ -579,11 +584,12 @@ def test_export_deprecated_versions_metrics__success(mocker):
         mocked_exit_event,
         mocked_error_event,
         HELM_V2_BINARY,
-        "v1.21.0",
+        K8s_VERSION,
+        MAXIMUM,
         app_data=app.app_data,
         lock=mocked_lock,
         data_file="tests/fixtures/data.json",
-        max=100,
+        helm_version=None,
     )
 
 


### PR DESCRIPTION
## Description

This PR is to support checking the used apiVersions of both Helm v2 and v3 releases at the same time with a flag --helm-version. The exported metrics will have the label helm_version so that we can filter Based on the Helm version.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x ] I have read the [contributing guidelines](https://github.com/wayfair-incubator/oss-template/blob/main/CONTRIBUTING.md)
- [x ] Existing issues have been referenced (where applicable)
- [x ] I have verified this change is not present in other open pull requests
- [x ] Functionality is documented
- [x ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x ] All new and existing tests pass
